### PR TITLE
Change behaviour of search for xpose.ini. 

### DIFF
--- a/R/xpose.data.R
+++ b/R/xpose.data.R
@@ -102,16 +102,22 @@ xpose.data <-function(runno,
     xpobj <- xpose.read(xpobj, file="xpose.ini")
   } else {
     ## read global options
-    rhome   <- R.home()
-    xdefini <- paste(rhome, "\\library\\xpose4\\xpose.ini", sep="")
+    ## Use .libPaths() to identify library installation directories
+    rhome   <- .libPaths()
+
+    ## Use file.path to append folder and file name to library paths
+    xdefiniPaths <- sapply(rhome, function(x){file.path(x, "xpose4","xpose.ini")})
+    ## Find whether the xpose.ini files exist in any of the library paths
+    xdefiniExists <- sapply(xdefiniPaths, file.exists)
+    ## Use the one nearest the top of the search path i.e. favour versions near top of library path
+    xdefini <- xdefiniPaths[min(which(xdefiniExists == TRUE))]
+    
+    ## Check that xpose.ini is readable
     if (is.readable.file(xdefini)) {
       xpobj <- xpose.read(xpobj, file=xdefini)
     }else{
-      xdefini2 <- paste(rhome, "\\library\\xpose4\\xpose.ini", sep="")
-      if (is.readable.file(xdefini2)) {
-        xpobj <- xpose.read(xpobj, file=xdefini2)
-      } 
-    }
+      cat("Cannot find a valid xpose.ini file!\n")
+      }
   }
 
   ## read tmp data into xpose object


### PR DESCRIPTION
Used .libPaths instead of R.home(). Add code to check xpose.ini exists in each .libPath entry and use the one nearest the top of the path. Using file.path instead of paste( ... ) since it's a little more robust. Using file.exists(...) to check existence of the xpose.ini in each libPath. Then picking the one that comes first in the libPath (if there's more than one).  Assumes that R looks in libPaths in order they appear in .libPath(). Usually user library location(s) first, then finally installation directory.